### PR TITLE
Remove buffer log

### DIFF
--- a/gulp-lodash-custom.js
+++ b/gulp-lodash-custom.js
@@ -68,9 +68,9 @@ module.exports = function (options) {
 
         gutil.log('starting lodash csutom build with following methods: ' + methods);
 
-        execLodashCli.stdout.on('data', function (data) {
-            gutil.log(data);
-        });
+//         execLodashCli.stdout.on('data', function (data) {
+//             gutil.log(data);
+//         });
 
         execLodashCli.stderr.on('data', function (error) {
             callback(error);

--- a/gulp-lodash-custom.js
+++ b/gulp-lodash-custom.js
@@ -68,10 +68,6 @@ module.exports = function (options) {
 
         gutil.log('starting lodash csutom build with following methods: ' + methods);
 
-//         execLodashCli.stdout.on('data', function (data) {
-//             gutil.log(data);
-//         });
-
         execLodashCli.stderr.on('data', function (error) {
             callback(error);
             return;


### PR DESCRIPTION
Hi, 

Just a suggestion. 
Why we need those non-human-readable buffer logs? 